### PR TITLE
Add job priority and description to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ container:
 cloud:
   region: "SR006"                                                                        # Cloud region to deploy the job
   instance_type: "a100plus.1gpu.80vG.12C.96G"                                            # Type of cloud instance
-  n_workers: 1                                                                           # Number of worker instances, 1 is only option 
+  n_workers: 1                                                                           # Number of worker instances, 1 is only option
+  priority: "medium"                                                                     # Job priority. Options: ['high', 'medium', 'low']
+  description: "test job"                                                                # Job description 
 ```
 
 ### Typical Use Case

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cloud:
   region: "SR006"                                                                        # Cloud region to deploy the job
   instance_type: "a100plus.1gpu.80vG.12C.96G"                                            # Type of cloud instance
   n_workers: 1                                                                           # Number of worker instances, 1 is only option
-  priority: "medium"                                                                     # Job priority. Options: ['high', 'medium', 'low']
+  priority: "medium"                                                                     # Job priority. Options: ['high', 'medium', 'low']. Jobs with higher priority will stop running jobs with lower priority if all resources are allocated.
   description: "test job"                                                                # Job description 
 ```
 

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -29,6 +29,8 @@ class CloudConfig(BaseModel):
     region: str = "SR006"
     instance_type: str = None
     n_workers: int = 1
+    priority: str = "medium"
+    description: str = None
 
 
 class CryConfig(BaseModel):
@@ -55,7 +57,9 @@ def submit_run(cfg):
         n_workers=1,
         region=cfg.cloud.region,
         type='binary',
-        env_variables=cfg.container.environment
+        env_variables=cfg.container.environment,
+        priority_class=cfg.cloud.priority,
+        job_desc=cfg.cloud.description,
     )
 
     status = mnist_tf_run.submit()

--- a/cryri/run.yaml
+++ b/cryri/run.yaml
@@ -10,3 +10,5 @@ cloud:
   region: "SR006"
   instance_type: "a100plus.1gpu.80vG.12C.96G"
   n_workers: 1
+  priority: "medium"
+  description: "test job"


### PR DESCRIPTION
Add job priority and description to configuration file. Job description of running jobs can be viewed in allocation dashboard. 