### PR TITLE
Fix copy dir name taking into account seconds

### DIFF
--- a/cryri/main.py
+++ b/cryri/main.py
@@ -21,7 +21,9 @@ def submit_run(cfg: CryConfig) -> str:
     """Submit a job run with the given configuration."""
     cfg.container.environment = expand_environment_vars_and_user(cfg.container.environment)
 
-    if cfg.container.run_from_copy and cfg.container.cry_copy_dir:
+    if cfg.container.run_from_copy:
+        assert cfg.container.cry_copy_dir, \
+            f'Copy dir is not set: {cfg.container.cry_copy_dir}'
         cfg.container.work_dir = create_run_copy(cfg)
 
     job_description = create_job_description(cfg)

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -13,7 +13,7 @@ from cryri.utils import (
 
 try:
     import client_lib
-except ImportError:
+except ModuleNotFoundError:
     logging.warning("client_lib not found. Some functionality may be limited.")
 
 

--- a/cryri/utils.py
+++ b/cryri/utils.py
@@ -28,9 +28,14 @@ def create_job_description(cfg: CryConfig) -> str:
 def create_run_copy(cfg: CryConfig) -> Path:
     """Create a copy of the work directory for the run."""
     copy_from_folder = Path(cfg.container.work_dir).parent.resolve()
-    now = datetime.now().strftime(DATETIME_FORMAT)
-    hash_suffix = hashlib.sha1(datetime.now().strftime(f"{DATETIME_FORMAT}S").encode()).hexdigest()[:HASH_LENGTH]
-    run_name = f"run_{now}_{hash_suffix}"
+
+    now = datetime.now()
+    now_str = now.strftime(DATETIME_FORMAT)
+    hash_suffix = hashlib.sha1(
+        now.strftime(f"{DATETIME_FORMAT}S").encode()
+    ).hexdigest()[:HASH_LENGTH]
+
+    run_name = f"run_{now_str}_{hash_suffix}"
     run_folder = Path(cfg.container.cry_copy_dir) / run_name
 
     ignore_fun = shutil.ignore_patterns(*cfg.container.exclude_from_copy)

--- a/cryri/utils.py
+++ b/cryri/utils.py
@@ -47,6 +47,7 @@ def create_run_copy(cfg: CryConfig) -> Path:
 
     return run_folder
 
+
 def expand_environment_vars_and_user(environment: dict):
     if environment is None:
         return None

--- a/cryri/utils.py
+++ b/cryri/utils.py
@@ -32,7 +32,7 @@ def create_run_copy(cfg: CryConfig) -> Path:
     now = datetime.now()
     now_str = now.strftime(DATETIME_FORMAT)
     hash_suffix = hashlib.sha1(
-        now.strftime(f"{DATETIME_FORMAT}S").encode()
+        now.strftime(f"{DATETIME_FORMAT}%S").encode()
     ).hexdigest()[:HASH_LENGTH]
 
     run_name = f"run_{now_str}_{hash_suffix}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,7 @@ def test_create_job_description_with_team(basic_config):
     description = create_job_description(basic_config)
     assert description == "-test-dir #test-team"
 
+
 def test_expand_vars_user(basic_config):
     from os import environ
     environ['EXISTING_VAR'] = '!SPECIAL_VALUE!'


### PR DESCRIPTION
This PR addresses and resolves a subtle but annoying issue related to the `run_from_copy: True` mode, which previously imposed a "single-run-per-minute" restriction. The root cause was an incorrect format string used for generating temporary folder names — specifically, the placeholder `f"{DATETIME_FORMAT}S"` did not properly include seconds. It has been corrected to `f"{DATETIME_FORMAT}%S"` to ensure unique folder names down to the second.

In addition:
 - Flake8 errors have been fixed to ensure code quality and consistency.
 - A previously silent fallback behavior has been replaced with an explicit exception: when `run_from_copy = True` but `cry_copy_dir` is unset (None or ''), the code would previously proceed without copying, potentially leading to confusion if the user immediate code modifications affect the starting run. This PR ensures that such misconfigurations are caught early by raising an error.