### PR TITLE
Extend env vars and user expansion for work_dir and cry_copy_dir 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,13 @@ cloud:
      run_from_copy: True
      ```
 
-5. **Environment variables propagation**
-   - You can pass (=propagate) environment variables directly, e.g. `"WANDB_API_KEY": "$WANDB_API_KEY"`. It will be expanded using your (=caller) current set of the environment variables before passing to the Job creation service.
-   - You can also pass paths relative to your HOME directory, e.g. `~/path/to/somewhere`. It will also be expanded using your `$HOME` variable.
+5. **Environment variables expansion**
+   - Several fields — `environment`, `work_dir`, `cry_copy_dir` — support environment variables `$XXX` and user home directory `~` expansion.
+   - With this feature, you can 
+     - pass environment variables directly to the docker container via `environment` field, e.g. `"WANDB_API_KEY": "$WANDB_API_KEY"`; 
+     - or use an env var to specify `cry_copy_dir` location `cry_copy_dir: $PERSONAL_HOME/.cryri`. 
+   - Expansion uses your (=caller) current context.
+   - You can also use paths relative to your HOME directory, e.g. `~/path/to/somewhere`. It will be expanded using your `$HOME` variable.
 
 ### View Logs
 

--- a/cryri/config.py
+++ b/cryri/config.py
@@ -1,15 +1,29 @@
-from typing import List, Dict
+from typing import List, Dict, Annotated
 
-from pydantic import BaseModel
+from pydantic import BaseModel, AfterValidator
+
+from cryri.validators import expand_vars_and_user, sanitize_dir_path
 
 
 class ContainerConfig(BaseModel):
     image: str = None
     command: str = None
-    environment: Dict = None
-    work_dir: str = None
+    environment: Annotated[Dict, AfterValidator(expand_vars_and_user)] = None
+
+    work_dir: Annotated[
+        str,
+        AfterValidator(expand_vars_and_user),
+        AfterValidator(sanitize_dir_path),
+    ] = None
+
     run_from_copy: bool = False
-    cry_copy_dir: str = None
+
+    cry_copy_dir: Annotated[
+        str,
+        AfterValidator(expand_vars_and_user),
+        AfterValidator(sanitize_dir_path),
+    ] = None
+
     exclude_from_copy: List[str] = []
 
 

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -8,7 +8,7 @@ import yaml
 from cryri.config import CryConfig, CloudConfig
 from cryri.job_manager import JobManager
 from cryri.utils import (
-    create_job_description, create_run_copy, expand_environment_vars_and_user
+    create_job_description, create_run_copy, expand_config_vars_and_user
 )
 
 try:
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 
 def submit_run(cfg: CryConfig) -> str:
     """Submit a job run with the given configuration."""
-    cfg.container.environment = expand_environment_vars_and_user(cfg.container.environment)
+    expand_config_vars_and_user(cfg.container)
 
     if cfg.container.run_from_copy:
         assert cfg.container.cry_copy_dir, \

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -8,7 +8,7 @@ import yaml
 from cryri.config import CryConfig, CloudConfig
 from cryri.job_manager import JobManager
 from cryri.utils import (
-    create_job_description, create_run_copy, expand_config_vars_and_user
+    create_job_description, create_run_copy, expand_config_vars_and_user, sanitize_config_paths
 )
 
 try:
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 def submit_run(cfg: CryConfig) -> str:
     """Submit a job run with the given configuration."""
     expand_config_vars_and_user(cfg.container)
+    sanitize_config_paths(cfg.container)
 
     if cfg.container.run_from_copy:
         assert cfg.container.cry_copy_dir, \

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -7,7 +7,7 @@ import yaml
 from cryri.config import CryConfig, CloudConfig
 from cryri.job_manager import JobManager
 from cryri.utils import (
-    create_job_description, create_run_copy, expand_config_vars_and_user, sanitize_config_paths
+    create_job_description, create_run_copy
 )
 
 try:
@@ -18,9 +18,6 @@ except ModuleNotFoundError:
 
 def submit_run(cfg: CryConfig) -> str:
     """Submit a job run with the given configuration."""
-    expand_config_vars_and_user(cfg.container)
-    sanitize_config_paths(cfg.container)
-
     if cfg.container.run_from_copy:
         assert cfg.container.cry_copy_dir, \
             f'Copy dir is not set: {cfg.container.cry_copy_dir}'

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -1,7 +1,6 @@
+import argparse
 import importlib
 import logging
-import argparse
-from pathlib import Path
 
 import yaml
 
@@ -25,16 +24,18 @@ def submit_run(cfg: CryConfig) -> str:
     if cfg.container.run_from_copy:
         assert cfg.container.cry_copy_dir, \
             f'Copy dir is not set: {cfg.container.cry_copy_dir}'
-        cfg.container.work_dir = create_run_copy(cfg)
+        cfg.container.work_dir = create_run_copy(cfg.container)
 
     job_description = create_job_description(cfg)
     logging.info("Submitting job with description: %s", job_description)
 
     try:
         quoted_command = cfg.container.command.replace('"', '\\"')
+        run_script = f'bash -c "cd {cfg.container.work_dir} && {quoted_command}"'
+
         job = client_lib.Job(
             base_image=cfg.container.image,
-            script=f'bash -c "cd {str(Path(cfg.container.work_dir).resolve())} && {quoted_command}"',
+            script=run_script,
             instance_type=cfg.cloud.instance_type,
             processes_per_worker=cfg.cloud.processes_per_worker,
             n_workers=cfg.cloud.n_workers,

--- a/cryri/utils.py
+++ b/cryri/utils.py
@@ -105,8 +105,7 @@ def expand_vars_and_user(
     # are expected to be present while they are not (e.g. rc-file sourcing failed)
     if "$" in s:
         logging.warning(
-            'After env vars expansion, the value still contains a `$`:\n'
-            '"%s"\n'
+            'After env vars expansion, the value still contains a `$`: "%s".\n'
             'Note: This might be a false alarm — just ensuring a potential silent issue '
             'does not go unnoticed.',
             s

--- a/cryri/utils.py
+++ b/cryri/utils.py
@@ -1,13 +1,11 @@
 import hashlib
-import logging
 import os
 import shutil
 from datetime import datetime
-from os.path import expanduser, expandvars
 from pathlib import Path
-from typing import Any, Union, List, Dict, Tuple, Optional
 
 from cryri.config import CryConfig, ContainerConfig
+from cryri.validators import expand_vars_and_user, sanitize_dir_path
 
 DATETIME_FORMAT = "%Y_%m_%d_%H%M"
 HASH_LENGTH = 6
@@ -66,66 +64,3 @@ def expand_config_vars_and_user(cfg: ContainerConfig):
 def sanitize_config_paths(cfg: ContainerConfig):
     cfg.work_dir = sanitize_dir_path(cfg.work_dir)
     cfg.cry_copy_dir = sanitize_dir_path(cfg.cry_copy_dir)
-
-
-def expand_vars_and_user(
-        s: Union[None, str, Tuple[Any], List[Any], Dict[Any, Any]]
-) -> Union[None, str, Tuple[Any], List[Any], Dict[Any, Any]]:
-    """
-    Universal function that returns a copy of an input with values expanded,
-    if they are str and contain known expandable parts (`~` home or `$XXX` env var).
-
-    Original object is returned iff it is not a subject for expansion. So, it's better
-    read as "this is not an in-place/mutating operation!"
-    """
-
-    if s is None:
-        return None
-
-    if isinstance(s, tuple):
-        # noinspection PyTypeChecker
-        return tuple(expand_vars_and_user(x) for x in s)
-
-    if isinstance(s, list):
-        return [expand_vars_and_user(x) for x in s]
-
-    if isinstance(s, dict):
-        return {k: expand_vars_and_user(v) for k, v in s.items()}
-
-    if not isinstance(s, str):
-        return s
-
-    # NB: expand vars then user, since vars could be expanded into a path
-    #   that requires user expansion
-    # NB: expect only known/existing environment vars to be expanded!
-    #   others will be left as-is
-    s = expanduser(expandvars(s))
-
-    # notify user if any $'s in the string to catch cases when env vars
-    # are expected to be present while they are not (e.g. rc-file sourcing failed)
-    if "$" in s:
-        logging.warning(
-            'After env vars expansion, the value still contains a `$`: "%s".\n'
-            'Note: This might be a false alarm — just ensuring a potential silent issue '
-            'does not go unnoticed.',
-            s
-        )
-
-    return s
-
-
-def sanitize_dir_path(p: Optional[str]) -> Optional[str]:
-    if p is None:
-        return None
-
-    # NB: it expects already expanded path
-    # NB: it expects an existing path (= all parts along the path are existing)
-
-    # resolve path => absolute normalized path
-    p = Path(p).resolve()
-
-    # drop non-dir last part => dir path
-    if not p.is_dir():
-        p = p.parent
-
-    return str(p)

--- a/cryri/utils.py
+++ b/cryri/utils.py
@@ -59,7 +59,6 @@ def expand_config_vars_and_user(cfg: ContainerConfig):
     cfg.environment = expand_vars_and_user(cfg.environment)
     cfg.work_dir = expand_vars_and_user(cfg.work_dir)
     cfg.cry_copy_dir = expand_vars_and_user(cfg.cry_copy_dir)
-    cfg.exclude_from_copy = expand_vars_and_user(cfg.exclude_from_copy)
 
 
 def sanitize_config_paths(cfg: ContainerConfig):

--- a/cryri/validators.py
+++ b/cryri/validators.py
@@ -1,0 +1,66 @@
+import logging
+from os.path import expanduser, expandvars
+from pathlib import Path
+from typing import Union, Tuple, Any, List, Dict, Optional
+
+
+def expand_vars_and_user(
+        s: Union[None, str, Tuple[Any], List[Any], Dict[Any, Any]]
+) -> Union[None, str, Tuple[Any], List[Any], Dict[Any, Any]]:
+    """
+    Universal function that returns a copy of an input with values expanded,
+    if they are str and contain known expandable parts (`~` home or `$XXX` env var).
+
+    Original object is returned iff it is not a subject for expansion. So, it's better
+    read as "this is not an in-place/mutating operation!"
+    """
+
+    if s is None:
+        return None
+
+    if isinstance(s, tuple):
+        # noinspection PyTypeChecker
+        return tuple(expand_vars_and_user(x) for x in s)
+
+    if isinstance(s, list):
+        return [expand_vars_and_user(x) for x in s]
+
+    if isinstance(s, dict):
+        return {k: expand_vars_and_user(v) for k, v in s.items()}
+
+    if not isinstance(s, str):
+        return s
+
+    # NB: expand vars then user, since vars could be expanded into a path
+    #   that requires user expansion
+    # NB: expect only known/existing environment vars to be expanded!
+    #   others will be left as-is
+    s = expanduser(expandvars(s))
+
+    # notify user if any $'s in the string to catch cases when env vars
+    # are expected to be present while they are not (e.g. rc-file sourcing failed)
+    if "$" in s:
+        logging.warning(
+            'After env vars expansion, the value still contains a `$`: "%s".\n'
+            'Note: This might be a false alarm — just ensuring a potential silent issue '
+            'does not go unnoticed.',
+            s
+        )
+
+    return s
+
+
+def sanitize_dir_path(p: Optional[str]) -> Optional[str]:
+    if p is None:
+        return None
+
+    # NB: it expects already expanded path
+    # NB: it expects an existing path (= all parts along the path are existing)
+
+    # resolve path => absolute normalized path
+    p = Path(p).resolve()
+
+    # assert path exists, can be accessed and is a directory
+    assert p.is_dir(), f'"{p}" is not a directory or path does not exist!'
+
+    return str(p)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -150,8 +150,8 @@ def test_expand_vars_and_user(expandable_struct, caplog):
     # Take last record, use .message for the actual string content
     actual_msg = caplog.records[-1].message
     expected_msg = (
-        'After env vars expansion, the value still contains a `$`:\n'
-        '"$NON_EXISTING_VAR/$100 bucks"\n'
+        'After env vars expansion, the value still contains a `$`: '
+        '"$NON_EXISTING_VAR/$100 bucks".\n'
         'Note: This might be a false alarm — just ensuring a potential silent issue '
         'does not go unnoticed.'
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,7 +44,6 @@ def test_container_config_defaults():
 
 @mock_path_resolution(cwd="/mock/fake/dir")
 def test_create_job_description_basic(basic_config):
-    assert basic_config.container.work_dir == "/test/dir"
     description = create_job_description(basic_config)
     assert description == "-test-dir"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,12 @@
 # pylint: disable=redefined-outer-name
 
 import pytest
+
 from cryri.config import CryConfig, ContainerConfig, CloudConfig
 from cryri.job_manager import JobManager
-from cryri.utils import create_job_description, expand_environment_vars_and_user
+from cryri.utils import (
+    create_job_description, expand_vars_and_user
+)
 
 
 @pytest.fixture
@@ -13,13 +16,6 @@ def basic_config():
             image="test-image:latest",
             command="python script.py",
             work_dir="/test/dir",
-            environment={
-                "TEST_VAR": "no expansion",
-                "TEST_VAR2": "$EXISTING_VAR",
-                "TEST_VAR3": "~/prefix/$EXISTING_VAR/suffix",
-                "TEST_VAR4": "~/prefix/$NON_EXISTING_VAR/suffix",
-                "TEST_VAR5": "$100 bucks",
-            }
         ),
         cloud=CloudConfig(
             region="SR006",
@@ -27,6 +23,42 @@ def basic_config():
             priority="medium"
         )
     )
+
+
+@pytest.fixture
+def expandable_struct():
+    return {
+        1: 2,
+        2: "$EXISTING_VAR",
+        331: None,
+        "TEST_VAR": "no expansion",
+        "TEST_VAR2": "$EXISTING_VAR",
+        "TEST_VAR3": "~/prefix/$EXISTING_VAR/suffix",
+        "TEST_VAR4": "~/prefix/$NON_EXISTING_VAR/suffix",
+        "TEST_VAR5": "$100 bucks",
+        "sub_dict": {
+            "TEST_VAR": "no expansion",
+            "TEST_VAR2": "$EXISTING_VAR",
+            "TEST_VAR3": "~/prefix/$EXISTING_VAR/suffix",
+            "TEST_VAR4": "~/prefix/$NON_EXISTING_VAR/suffix",
+        },
+        "sub_list": [
+            None,
+            "TEST_VAR",
+            "$EXISTING_VAR",
+            "~/prefix:$EXISTING_VAR/suffix",
+            "~/prefix:$NON_EXISTING_VAR/suffix",
+        ],
+        "sub_tuple": (
+            133,
+            None,
+            "TEST_VAR",
+            "$100 bucks",
+            "$EXISTING_VAR",
+            "~ prefix $EXISTING_VAR suffix",
+            "~prefix $EXISTING_VAR1 suffix",
+        ),
+    }
 
 
 @pytest.fixture
@@ -55,18 +87,51 @@ def test_create_job_description_with_team(basic_config):
     assert description == "-test-dir #test-team"
 
 
-def test_expand_vars_user(basic_config):
+def test_expand_vars_and_user(expandable_struct):
+    # ====> Preparation
     from os import environ
     environ['EXISTING_VAR'] = '!SPECIAL_VALUE!'
 
     # sets both UNIX and WINDOWS user home vars
     environ['HOME'] = '<SOME_PATH>'
     environ['USERPROFILE'] = '<SOME_PATH>'
+    # <====
 
-    env = basic_config.container.environment
-    env = expand_environment_vars_and_user(env)
-    assert env['TEST_VAR'] == 'no expansion'
-    assert env['TEST_VAR2'] == '!SPECIAL_VALUE!'
-    assert env['TEST_VAR3'] == '<SOME_PATH>/prefix/!SPECIAL_VALUE!/suffix'
-    assert env['TEST_VAR4'] == '<SOME_PATH>/prefix/$NON_EXISTING_VAR/suffix'
-    assert env['TEST_VAR5'] == '$100 bucks'
+    _expandable_struct = expand_vars_and_user(expandable_struct)
+    assert _expandable_struct is not expandable_struct
+    expandable_struct = _expandable_struct
+
+    assert expandable_struct == {
+        1: 2,
+        2: "!SPECIAL_VALUE!",
+        331: None,
+        "TEST_VAR": "no expansion",
+        "TEST_VAR2": "!SPECIAL_VALUE!",
+        "TEST_VAR3": "<SOME_PATH>/prefix/!SPECIAL_VALUE!/suffix",
+        "TEST_VAR4": "<SOME_PATH>/prefix/$NON_EXISTING_VAR/suffix",
+        "TEST_VAR5": "$100 bucks",
+        "sub_dict": {
+            "TEST_VAR": "no expansion",
+            "TEST_VAR2": "!SPECIAL_VALUE!",
+            "TEST_VAR3": "<SOME_PATH>/prefix/!SPECIAL_VALUE!/suffix",
+            "TEST_VAR4": "<SOME_PATH>/prefix/$NON_EXISTING_VAR/suffix",
+        },
+        "sub_list": [
+            None,
+            "TEST_VAR",
+            "!SPECIAL_VALUE!",
+            "<SOME_PATH>/prefix:!SPECIAL_VALUE!/suffix",
+            "<SOME_PATH>/prefix:$NON_EXISTING_VAR/suffix",
+        ],
+        "sub_tuple": (
+            133,
+            None,
+            "TEST_VAR",
+            "$100 bucks",
+            "!SPECIAL_VALUE!",
+            "~ prefix !SPECIAL_VALUE! suffix",
+            "~prefix $EXISTING_VAR1 suffix",
+        ),
+    }
+
+    assert None is expand_vars_and_user(None)

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+
+from tests.utils.mocks import mock_env_vars, mock_path_resolution, make_is_dir_mock
+
+
+@mock_env_vars(HOME="/mock/fake_user", MY_VAR="something")
+def test_mocking_env():
+    assert os.environ["HOME"] == "/mock/fake_user"
+    assert os.environ["USERPROFILE"] == "/mock/fake_user"
+    assert os.environ["MY_VAR"] == "something"
+
+
+def test_mocking_env_exclude():
+    @mock_env_vars(SOME_VAR="some value")
+    def with_var():
+        assert os.environ["SOME_VAR"] == "some value"
+
+        @mock_env_vars(__exclude__=["SOME_VAR"])
+        def no_var():
+            assert "SOME_VAR" not in os.environ
+        no_var()
+
+    with_var()
+
+
+@mock_env_vars(HOME="/mock/fake_user")
+@mock_path_resolution(
+    cwd="/mock/fake/dir", extra_resolve_map={
+        "config.yaml": "/mock/faky/fake/dir/config.yaml"
+    }
+)
+def test_mocking_path_expanduser():
+    def expanduser(path):
+        return str(Path(path).expanduser())
+
+    assert expanduser('/') == "/"
+    assert expanduser("~/.app") == "/mock/fake_user/.app"
+    assert expanduser(".") == "."
+    assert expanduser("config.yaml") == "config.yaml"
+    assert expanduser("./path/config.yaml") == "path/config.yaml"
+
+
+@mock_env_vars(HOME="/mock/fake_user")
+@mock_path_resolution(
+    cwd="/mock/fake/dir", extra_resolve_map={
+        "config.yaml": "/mock/faky/fake/dir/config.yaml"
+    }
+)
+def test_mocking_path_resolve():
+    def resolve(path):
+        return str(Path(path).resolve())
+
+    assert resolve('/') == "/"
+    assert resolve("~/.app") == "/mock/fake/dir/~/.app"
+    assert resolve(".") == "/mock/fake/dir"
+    assert resolve("config.yaml") == "/mock/faky/fake/dir/config.yaml"
+    assert resolve("./path/config.yaml") == "/mock/fake/dir/path/config.yaml"
+
+
+@mock_env_vars(HOME="/mock/fake_user")
+@mock_path_resolution(cwd="/mock/fake/dir")
+def test_mocking_path_expanduser_resolve():
+    def expanduser_resolve(path):
+        return str(Path(path).expanduser().resolve())
+
+    assert expanduser_resolve("~/.app") == "/mock/fake_user/.app"
+
+
+@mock_path_resolution(force_is_dir=False)
+def test_mocking_is_dir_false():
+    assert not Path(".").is_dir()
+    assert not Path("any/path").is_dir()
+
+
+@mock_path_resolution(cwd="/mock/fake/dir", force_is_dir=True)
+def test_mocking_is_dir_true():
+    assert Path(".").is_dir()
+    assert Path("any/path").is_dir()
+
+
+@mock_path_resolution(force_is_dir=make_is_dir_mock())
+def test_mocking_is_dir_dir_like():
+    assert Path(".").is_dir()
+    assert Path("dir/like/path").is_dir()
+    assert Path("/dir/like/path/").is_dir()
+
+
+@mock_path_resolution(force_is_dir=make_is_dir_mock())
+def test_mocking_is_dir_file_like():
+    assert Path("path/.config").is_dir()
+    assert not Path("some/known/ext.txt").is_dir()
+    assert not Path("some/known/ext/config.yaml").is_dir()
+    assert not Path("xxxx.md").is_dir()
+    assert Path(".yaml").is_dir()
+    assert Path("path/file.unknown_ext").is_dir()
+
+
+@mock_path_resolution(force_is_dir=make_is_dir_mock({".test1"}))
+def test_mocking_is_dir_file_like_custom_ext():
+    assert not Path("xx.test1").is_dir()
+    assert not Path("/path/to/xxx.test1").is_dir()
+    assert Path(".test1").is_dir()
+    assert Path("some/known/ext.txt").is_dir()
+    assert Path("config.yaml").is_dir()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,140 @@
+# pylint: disable=redefined-outer-name
+import pytest
+
+from cryri.validators import expand_vars_and_user, sanitize_dir_path
+from tests.utils.mocks import mock_env_vars, mock_path_resolution, make_is_dir_mock
+
+
+@pytest.fixture
+def expandable_struct():
+    return {
+        1: 2,
+        2: "$EXISTING_VAR",
+        331: None,
+        "TEST_VAR": "no expansion",
+        "TEST_VAR2": "$EXISTING_VAR",
+        "TEST_VAR3": "~/prefix/$EXISTING_VAR/suffix",
+        "TEST_VAR4": "~/prefix/$NON_EXISTING_VAR/suffix",
+        "TEST_VAR5": "$100 bucks",
+        "sub_dict": {
+            "TEST_VAR": "no expansion",
+            "TEST_VAR2": "$EXISTING_VAR",
+            "TEST_VAR3": "~/prefix/$EXISTING_VAR/suffix",
+            "TEST_VAR4": "~/prefix/$NON_EXISTING_VAR/suffix",
+        },
+        "sub_list": [
+            None,
+            "TEST_VAR",
+            "$EXISTING_VAR",
+            "~/prefix:$EXISTING_VAR/suffix",
+            "~/prefix:$NON_EXISTING_VAR/suffix",
+            "prefix/~:$NON_EXISTING_VAR/suffix",
+        ],
+        "sub_tuple": (
+            133,
+            None,
+            "TEST_VAR",
+            "$100 bucks",
+            "$EXISTING_VAR",
+            "~ prefix $EXISTING_VAR suffix",
+            "~prefix $EXISTING_VAR1 suffix",
+        ),
+    }
+
+
+@mock_env_vars(
+    HOME="<SOME_PATH>", EXISTING_VAR="!SPECIAL_VALUE!",
+    __exclude__=["NON_EXISTING_VAR"]
+)
+def test_expand_vars_and_user(expandable_struct):
+    result = expand_vars_and_user(expandable_struct)
+
+    # Check #1: a copy is returned (since it is subject for expansion)
+    assert result is not expandable_struct
+
+    # Check #2: correct expansion
+    assert result == {
+        1: 2,
+        2: "!SPECIAL_VALUE!",
+        331: None,
+        "TEST_VAR": "no expansion",
+        "TEST_VAR2": "!SPECIAL_VALUE!",
+        "TEST_VAR3": "<SOME_PATH>/prefix/!SPECIAL_VALUE!/suffix",
+        "TEST_VAR4": "<SOME_PATH>/prefix/$NON_EXISTING_VAR/suffix",
+        "TEST_VAR5": "$100 bucks",
+        "sub_dict": {
+            "TEST_VAR": "no expansion",
+            "TEST_VAR2": "!SPECIAL_VALUE!",
+            "TEST_VAR3": "<SOME_PATH>/prefix/!SPECIAL_VALUE!/suffix",
+            "TEST_VAR4": "<SOME_PATH>/prefix/$NON_EXISTING_VAR/suffix",
+        },
+        "sub_list": [
+            None,
+            "TEST_VAR",
+            "!SPECIAL_VALUE!",
+            "<SOME_PATH>/prefix:!SPECIAL_VALUE!/suffix",
+            "<SOME_PATH>/prefix:$NON_EXISTING_VAR/suffix",
+            "prefix/~:$NON_EXISTING_VAR/suffix",
+        ],
+        "sub_tuple": (
+            133,
+            None,
+            "TEST_VAR",
+            "$100 bucks",
+            "!SPECIAL_VALUE!",
+            "~ prefix !SPECIAL_VALUE! suffix",
+            "~prefix $EXISTING_VAR1 suffix",
+        ),
+    }
+
+    # Check #3: gracefully support None input
+    assert expand_vars_and_user(None) is None
+
+
+@mock_env_vars(__exclude__=["NON_EXISTING_VAR"])
+def test_expand_vars_and_user_warning(caplog):
+    # Check: warns user if any "$" signs in a resulting strings
+    with caplog.at_level("WARNING"):
+        _ = expand_vars_and_user("$NON_EXISTING_VAR/$100 bucks")
+
+    # There should be any warnings (from previous calls and the last one)
+    assert caplog.records
+
+    # Take last record, use .message for the actual string content
+    actual_msg = caplog.records[-1].message
+    expected_msg = (
+        'After env vars expansion, the value still contains a `$`: '
+        '"$NON_EXISTING_VAR/$100 bucks".\n'
+        'Note: This might be a false alarm — just ensuring a potential silent issue '
+        'does not go unnoticed.'
+    )
+
+    assert actual_msg == expected_msg
+
+
+def test_sanitize_dir_path_none():
+    assert sanitize_dir_path(None) is None
+
+
+@mock_path_resolution(cwd="/mock/dir", force_is_dir=False)
+def test_sanitize_dir_path_non_existing_dir():
+    with pytest.raises(AssertionError, match="does not exist"):
+        sanitize_dir_path("non_existing_dir")
+    with pytest.raises(AssertionError, match="does not exist"):
+        sanitize_dir_path("/path/to/non_existing_dir")
+
+
+@mock_path_resolution(cwd="/mock/dir", force_is_dir=make_is_dir_mock())
+def test_sanitize_dir_path_is_not_dir():
+    with pytest.raises(AssertionError, match="not a directory"):
+        sanitize_dir_path("file.txt")
+    with pytest.raises(AssertionError, match="not a directory"):
+        sanitize_dir_path("/path/to/config.yaml")
+
+
+@mock_path_resolution(cwd="/mock/dir", force_is_dir=make_is_dir_mock())
+def test_sanitize_dir_path_resolve():
+    assert sanitize_dir_path(".") == "/mock/dir"
+    assert sanitize_dir_path("/") == "/"
+    assert sanitize_dir_path("./.config") == "/mock/dir/.config"
+    assert sanitize_dir_path("./.config") == "/mock/dir/.config"

--- a/tests/utils/mocks.py
+++ b/tests/utils/mocks.py
@@ -1,0 +1,97 @@
+import os
+import tempfile
+from contextlib import ExitStack
+from functools import wraps
+from pathlib import Path
+from unittest.mock import patch
+
+
+def mock_env_vars(__exclude__=None, **env_vars):
+    """
+    Decorator to patch environment variables.
+    Usage: @mock_env_vars(
+            HOME="/fake/home", MY_VAR="value", __exclude__=["TO_BE_NON_EXISTING_VAR"]
+        )
+    """
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(*args, **kwargs):
+            with patch.dict(os.environ, env_vars, clear=False):
+                # Delete excluded keys from os.environ temporarily
+                to_restore = {k: os.environ[k] for k in __exclude__ if k in os.environ}
+                for k in to_restore:
+                    os.environ.pop(k)
+                try:
+                    return test_func(*args, **kwargs)
+                finally:
+                    os.environ.update(to_restore)
+        return wrapper
+
+    # set of excluded keys
+    __exclude__ = set(__exclude__ or [])
+
+    # automatically add 'USERPROFILE' if 'HOME' is present to cover WINDOWS case too
+    if 'HOME' in env_vars and 'USERPROFILE' not in env_vars:
+        env_vars['USERPROFILE'] = env_vars['HOME']
+
+    return decorator
+
+
+def make_is_dir_mock(file_extensions=None):
+    """Construct a mock for `Path.is_dir()` method based on a file extension presence."""
+    def _mock(self: Path) -> bool:
+        return self.suffix not in file_extensions
+
+    if isinstance(file_extensions, str):
+        file_extensions = {file_extensions}
+    file_extensions = file_extensions or {".py", ".yaml", ".json", ".env", ".txt", ".md"}
+    return _mock
+
+
+def mock_path_resolution(
+        cwd=None, extra_resolve_map=None, force_is_dir=make_is_dir_mock
+):
+    """
+    Decorator to mock Path.resolve(), cwd, and optionally Path.is_dir().
+
+    Args:
+        cwd (str): mocked current working directory. Defaults to temp dir.
+        extra_resolve_map (dict): maps input path strings to resolved output strings.
+        force_is_dir (bool | callable): if True or False, patches Path.is_dir().
+            If callable(Path) -> bool, uses custom logic per path.
+    """
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(*args, **kwargs):
+            # Fake Path.resolve() logic
+            def custom_resolve(self: Path):
+                key = str(self)
+                if extra_resolve_map and key in extra_resolve_map:
+                    return Path(extra_resolve_map[key])
+                return Path(os.path.join(self.cwd(), key))
+
+            # Fake Path.is_dir() logic (optional)
+            def is_dir_wrapper(self: Path):
+                if callable(force_is_dir):
+                    return force_is_dir(self)
+                return bool(force_is_dir)
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # use provided cwd or create temp dir (which is auto-deleted)
+                target_cwd = Path(cwd or temp_dir)
+
+                # fancy dynamic way of stacking `with` context managers
+                with ExitStack() as stack:
+                    stack.enter_context(patch("os.getcwd", return_value=str(target_cwd)))
+                    stack.enter_context(patch("pathlib.Path.cwd", return_value=target_cwd))
+                    stack.enter_context(patch("pathlib.Path.resolve", new=custom_resolve))
+
+                    if force_is_dir is not None:
+                        stack.enter_context(
+                            patch("pathlib.Path.is_dir", new=is_dir_wrapper)
+                        )
+
+                    return test_func(*args, **kwargs)
+
+        return wrapper
+    return decorator


### PR DESCRIPTION
This PR extends the expansion logic for environment variables (`$XXX`) and user home directories (`~`) to include the `work_dir` and `cry_copy_dir` fields, ensuring these paths are fully resolved and interpreted correctly. Readme is updated accordingly to mention it, with examples.

Additional improvements:
- **Pylint fixes**: Addresses and resolves all outstanding pylint warnings for cleaner, compliant code.
- **Improved logging for unexpanded variables**: Adds explicit warnings when expanded strings still contain a `$`, which may indicate missing or misconfigured environment variables (e.g. due to a failed or forgotten rc-file sourcing). This helps prevent silent misconfigurations.
- **Unified path formatting and sanitization**: Standardizes how path-like variables are processed and normalized, reducing the likelihood of bugs caused by redundant or missing normalization and resolution steps.
- **Bug fix for work_dir resolution**: Corrects an issue where `work_dir` could incorrectly resolve to its parent directory in certain cases.