### PR TITLE
Command batching for single-job submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ pip install git+https://github.com/Tviskaron/cryri.git
 
 ## Features
 
+### Batching Terminology
+
+To make batching abstractions explicit, cryri uses these names:
+
+- **Submission Unit**: one cloud job submitted by cryri (one `/run_job` API call).
+- **Command Batch**: multiple shell commands inside a single Submission Unit.
+  - `container.command` is a **string** -> single command (no batching).
+  - `container.command` is a **list** -> batched command execution in one job.
+  - `container.execution.parallel` controls how many commands run in parallel per batch.
+
 ### List Running Jobs
 
 
@@ -35,7 +45,7 @@ cryri --instance_types --region SR006
 
 Submit a containerized job using a YAML configuration file:
 
-The configuration file must follow the structure defined below: 
+The configuration file must follow the structure defined below:
 
 ```bash
 cryri run.yaml
@@ -56,40 +66,60 @@ cloud:
   region: "SR006"                                                                        # Cloud region to deploy the job
   instance_type: "a100plus.1gpu.80vG.12C.96G"                                            # Type of cloud instance
   n_workers: 1                                                                           # Number of worker instances, 1 is only option
-  description: "test job"                                                                # Job description 
+  description: "test job"                                                                # Job description
+```
+
+Command batching example (single submission, 3 commands in parallel at a time):
+
+```yaml
+container:
+  image: "cr.ai.cloud.ru/your/image"
+  command:
+    - "echo start && sleep 1"
+    - "echo step-1 && sleep 2"
+    - "echo step-2 && sleep 2"
+    - "echo step-3 && sleep 2"
+    - "echo done"
+  execution:
+    parallel: 3
+  work_dir: "."
+cloud:
+  region: "SR006"
+  instance_type: "cpu.2C.8G"
+  n_workers: 1
 ```
 
 ### Typical Use Case
 
 1. **Prepare Docker Image** (see recommendations below)
-   - Build your Docker image, tag it with the `job-custom-image-` prefix, and push it to the cloud registry.  
+   - Build your Docker image, tag it with the `job-custom-image-` prefix, and push it to the cloud registry.
    - Example: Use the image `job-custom-image-follower` or create your own with the required prefix.
 
-2. **Set Up Local Directory**  
-   - Create a local directory containing the code for your job. The simplest way is to clone a repository from GitHub.  
-     Example for the "Follower" project:  
+2. **Set Up Local Directory**
+   - Create a local directory containing the code for your job. The simplest way is to clone a repository from GitHub.
+     Example for the "Follower" project:
      ```bash
      git clone https://github.com/CognitiveAISystems/learn-to-follow
      ```
 
-3. **Create and Run Job**  
-   - Inside the folder, create a `run.yaml` file with the necessary configuration. You can use the example provided earlier as a template.  
-   - Start the job using:  
+3. **Create and Run Job**
+   - Inside the folder, create a `run.yaml` file with the necessary configuration. You can use the example provided earlier as a template.
+   - Start the job using:
      ```bash
      cryri run.yaml
      ```
 
-4. **Concurrent Experimentation**  
-   - For multiple concurrent experiments from the same directory, set the `run_from_copy` flag to `True` in `run.yaml`. This ensures each run uses a unique directory, stored at the `cry_copy_dir` path.  
+4. **Concurrent Experimentation**
+   - For multiple concurrent experiments from the same directory, set the `run_from_copy` flag to `True` in `run.yaml`. This ensures each run uses a unique directory, stored at the `cry_copy_dir` path.
      ```yaml
      run_from_copy: True
      ```
 
 5. **Environment variables expansion**
    - Several fields — `environment`, `work_dir`, `cry_copy_dir` — support environment variables `$XXX` and user home directory `~` expansion.
-   - With this feature, you can 
-     - pass environment variables directly to the docker container via `environment` field, e.g. `"WANDB_API_KEY": "$WANDB_API_KEY"`; 
-     - or use an env var to specify `cry_copy_dir` location `cry_copy_dir: $PERSONAL_HOME/.cryri`. 
+   - With this feature, you can
+     - pass environment variables directly to the docker container via `environment` field, e.g. `"WANDB_API_KEY": "$WANDB_API_KEY"`;
+     - or use an env var to specify `cry_copy_dir` location `cry_copy_dir: $PERSONAL_HOME/.cryri`.
    - Expansion uses your (=caller) current context.
    - You can also use paths relative to your HOME directory, e.g. `~/path/to/somewhere`. It will be expanded using your `$HOME` variable.
 

--- a/cryri/config.py
+++ b/cryri/config.py
@@ -1,6 +1,6 @@
-from typing import Optional, List, Dict, Annotated
+from typing import Optional, List, Dict, Annotated, Union
 
-from pydantic import BaseModel, AfterValidator, ConfigDict
+from pydantic import BaseModel, AfterValidator, ConfigDict, Field, model_validator
 
 from cryri.validators import expand_vars_and_user, sanitize_dir_path
 
@@ -11,7 +11,7 @@ class ContainerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     image: Optional[str] = None
-    command: Optional[str] = None
+    command: Optional[Union[str, List[str]]] = None
     environment: Annotated[Optional[Dict], AfterValidator(expand_vars_and_user)] = None
 
     work_dir: Annotated[
@@ -28,7 +28,34 @@ class ContainerConfig(BaseModel):
         AfterValidator(sanitize_dir_path),
     ] = None
 
-    exclude_from_copy: List[str] = []
+    exclude_from_copy: List[str] = Field(default_factory=list)
+    execution: "ExecutionConfig" = Field(default_factory=lambda: ExecutionConfig())
+
+    @model_validator(mode="after")
+    def validate_command_and_execution(self):
+        if isinstance(self.command, list):
+            if not self.command:
+                raise ValueError("container.command list must not be empty")
+            for idx, cmd in enumerate(self.command, start=1):
+                if not isinstance(cmd, str) or not cmd.strip():
+                    raise ValueError(f"container.command[{idx}] must be a non-empty string")
+        elif isinstance(self.command, str):
+            if not self.command.strip():
+                raise ValueError("container.command must not be empty")
+            if self.execution.parallel != 1:
+                raise ValueError("container.execution.parallel is only supported when command is a list")
+        return self
+
+
+class ExecutionConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    parallel: int = 1
+
+    @model_validator(mode="after")
+    def validate_parallel(self):
+        if self.parallel < 0:
+            raise ValueError("container.execution.parallel must be >= 0")
+        return self
 
 
 class CloudConfig(BaseModel):

--- a/cryri/display.py
+++ b/cryri/display.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.markup import escape
 from rich.panel import Panel
-from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.prompt import Confirm, Prompt
 from rich.table import Table
 from rich.text import Text
 

--- a/cryri/display.py
+++ b/cryri/display.py
@@ -4,12 +4,14 @@ from typing import List, Dict
 
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.markup import escape
 from rich.panel import Panel
 from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 from rich.text import Text
 
 _SECRET_KEY_RE = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD)", re.IGNORECASE)
+_BATCH_COLORS = ["cyan", "green", "magenta", "yellow", "blue", "bright_cyan"]
 
 console = Console()
 
@@ -31,7 +33,18 @@ def render_config_panel(cfg) -> Panel:
     if c.image:
         lines.append(f"[bold]Image:[/bold]         {c.image}")
     if c.command:
-        lines.append(f"[bold]Command:[/bold]       {c.command}")
+        if isinstance(c.command, list):
+            lines.append(f"[bold]Commands:[/bold]      {len(c.command)} entries")
+            lines.append(f"[bold]Parallel:[/bold]      {c.execution.parallel}")
+            total_batches = 1 if c.execution.parallel <= 0 else (len(c.command) + c.execution.parallel - 1) // c.execution.parallel
+            for idx, cmd in enumerate(c.command, start=1):
+                batch_idx = 1 if c.execution.parallel <= 0 else ((idx - 1) // c.execution.parallel) + 1
+                color = _BATCH_COLORS[(batch_idx - 1) % len(_BATCH_COLORS)]
+                lines.append(
+                    f"  [{color}]{batch_idx}/{total_batches}: {escape(cmd)}[/{color}]"
+                )
+        else:
+            lines.append(f"[bold]Command:[/bold]       {c.command}")
     if cl.instance_type:
         lines.append(f"[bold]Instance:[/bold]      {cl.instance_type}")
     if cl.region:
@@ -41,7 +54,7 @@ def render_config_panel(cfg) -> Panel:
     if c.work_dir:
         lines.append(f"[bold]Work dir:[/bold]      {c.work_dir}")
     if c.run_from_copy:
-        lines.append(f"[bold]Run from copy:[/bold] True")
+        lines.append("[bold]Run from copy:[/bold] True")
     if cl.description:
         lines.append(f"[bold]Description:[/bold]   {cl.description}")
     if c.environment:

--- a/cryri/job_manager.py
+++ b/cryri/job_manager.py
@@ -6,6 +6,7 @@ from contextlib import redirect_stdout
 from cryri import api
 from cryri.api import ApiError
 from cryri.config import CryConfig
+from cryri.script_builder import create_batch_script_file
 from cryri.utils import create_run_copy, create_job_description
 
 
@@ -116,8 +117,17 @@ class JobManager:
 
         job_description = create_job_description(cfg)
 
-        quoted_dir = shlex.quote(cfg.container.work_dir)
-        run_script = f"bash -c {shlex.quote(f'cd {quoted_dir} && {cfg.container.command}')}"
+        if isinstance(cfg.container.command, list):
+            script_name = create_batch_script_file(
+                work_dir=cfg.container.work_dir,
+                commands=cfg.container.command,
+                parallel=cfg.container.execution.parallel,
+            )
+            quoted_dir = shlex.quote(cfg.container.work_dir)
+            run_script = f"bash -c {shlex.quote(f'cd {quoted_dir} && bash {shlex.quote(script_name)}')}"
+        else:
+            quoted_dir = shlex.quote(cfg.container.work_dir)
+            run_script = f"bash -c {shlex.quote(f'cd {quoted_dir} && {cfg.container.command}')}"
 
         if api.use_legacy_backend():
             client_lib = _require_client_lib()

--- a/cryri/main.py
+++ b/cryri/main.py
@@ -9,7 +9,7 @@ from rich.prompt import Confirm
 
 from cryri import __version__
 from cryri.api import ApiError
-from cryri.config import CryConfig, CloudConfig, DEFAULT_REGION
+from cryri.config import CryConfig, DEFAULT_REGION
 from cryri.display import (
     console,
     setup_logging,
@@ -20,7 +20,6 @@ from cryri.display import (
     interactive_job_select,
     print_success,
     print_error,
-    prompt_text,
     prompt_select,
 )
 from cryri.job_manager import JobManager, JobNotFoundError, ClientLibMissingError

--- a/cryri/script_builder.py
+++ b/cryri/script_builder.py
@@ -87,7 +87,7 @@ def build_script(commands: List[str], parallel: int, work_dir: str) -> str:
 
 
 def create_batch_script_file(work_dir: str, commands: List[str], parallel: int) -> str:
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     script_name = f"{timestamp}_{os.getpid()}.sh"
 
     scripts_dir = Path(work_dir) / ".cryri" / "batch_scripts"

--- a/cryri/script_builder.py
+++ b/cryri/script_builder.py
@@ -1,0 +1,103 @@
+import os
+import shlex
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+
+def _chunk_commands(commands: List[str], parallel: int) -> List[List[Tuple[int, str]]]:
+    indexed = list(enumerate(commands, start=1))
+    if parallel <= 0:
+        return [indexed]
+    return [indexed[i:i + parallel] for i in range(0, len(indexed), parallel)]
+
+
+def _escape_for_echo(cmd: str) -> str:
+    return cmd.replace('"', '\\"')
+
+
+def _append_batch_start(lines: List[str], batch_idx: int, total_batches: int, start_idx: int, end_idx: int) -> None:
+    lines.append(f"echo \"[cryri] === Batch {batch_idx}/{total_batches} (commands {start_idx}-{end_idx}) ===\"")
+
+
+def _append_batch_end(lines: List[str], batch_idx: int, total_batches: int) -> None:
+    lines.append(f"echo \"[cryri] === Batch {batch_idx}/{total_batches} done ===\"")
+
+
+def _append_launch_command(lines: List[str], cmd_idx: int, total: int, cmd: str) -> None:
+    escaped = _escape_for_echo(cmd)
+    lines.append(f"echo \"[cryri] [{cmd_idx}/{total}] {escaped}\"")
+    lines.append(f"bash -lc {shlex.quote(cmd)} &")
+    lines.append(f"PID_{cmd_idx}=$!")
+
+
+def _append_wait_command(lines: List[str], cmd_idx: int, cmd: str) -> None:
+    escaped = _escape_for_echo(cmd)
+    lines.append(f"wait $PID_{cmd_idx}")
+    lines.append("EC=$?")
+    lines.append(
+        f"if [ $EC -ne 0 ]; then echo \"[cryri] FAILED (exit $EC): {escaped}\"; FAIL=$((FAIL+1)); fi"
+    )
+
+
+def _append_final_summary(lines: List[str]) -> None:
+    lines.extend([
+        "echo \"[cryri] ===============================\"",
+        "if [ $FAIL -ne 0 ]; then",
+        "  echo \"[cryri] WARNING: $FAIL/$TOTAL_CMDS commands failed\"",
+        "  exit 1",
+        "fi",
+        "echo \"[cryri] All $TOTAL_CMDS commands completed successfully\"",
+    ])
+
+
+def _build_script_lines(commands: List[str], parallel: int) -> List[str]:
+    chunks = _chunk_commands(commands, parallel)
+    total = len(commands)
+    total_batches = len(chunks)
+
+    lines = [
+        "set +e",
+        "FAIL=0",
+        f"TOTAL_CMDS={total}",
+        f"echo \"[cryri] Starting execution: {total} commands, parallel={parallel}, {total_batches} batches\"",
+    ]
+
+    for batch_idx, batch in enumerate(chunks, start=1):
+        start_idx = batch[0][0]
+        end_idx = batch[-1][0]
+        _append_batch_start(lines, batch_idx, total_batches, start_idx, end_idx)
+
+        for cmd_idx, cmd in batch:
+            _append_launch_command(lines, cmd_idx, total, cmd)
+
+        for cmd_idx, cmd in batch:
+            _append_wait_command(lines, cmd_idx, cmd)
+
+        _append_batch_end(lines, batch_idx, total_batches)
+
+    _append_final_summary(lines)
+    return lines
+
+
+def build_script(commands: List[str], parallel: int, work_dir: str) -> str:
+    lines = [f"cd {shlex.quote(work_dir)} || exit 1"]
+    lines.extend(_build_script_lines(commands, parallel))
+    return "bash -c " + shlex.quote("\n".join(lines))
+
+
+def create_batch_script_file(work_dir: str, commands: List[str], parallel: int) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    script_name = f"{timestamp}_{os.getpid()}.sh"
+
+    scripts_dir = Path(work_dir) / ".cryri" / "batch_scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    script_path = scripts_dir / script_name
+
+    script_lines = ["#!/usr/bin/env bash", * _build_script_lines(commands, parallel)]
+
+    script_path.write_text("\n".join(script_lines) + "\n", encoding="utf-8")
+    os.chmod(script_path, 0o755)
+
+    return str(script_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,6 +45,7 @@ def test_container_config_defaults():
     assert config.work_dir is None
     assert config.run_from_copy is False
     assert config.cry_copy_dir is None
+    assert config.execution.parallel == 1
 
 
 @mock_path_resolution(cwd="/mock/fake/dir")
@@ -87,6 +88,23 @@ def test_container_config_expand_resolve_fields_validators():
     }
     assert config.work_dir == "/mock/fake_dir"
     assert config.cry_copy_dir == "/mock/fake_user/sub_user/.cryri"
+
+
+def test_container_config_command_list_and_parallel_valid():
+    cfg = ContainerConfig(
+        command=["echo one", "echo two"],
+        execution={"parallel": 2},
+    )
+    assert isinstance(cfg.command, list)
+    assert cfg.execution.parallel == 2
+
+
+def test_container_config_string_command_parallel_rejected():
+    with pytest.raises(ValueError):
+        ContainerConfig(
+            command="echo one",
+            execution={"parallel": 2},
+        )
 
 
 def test_version():

--- a/tests/test_submit_run.py
+++ b/tests/test_submit_run.py
@@ -66,3 +66,53 @@ def test_submit_run_executes_command(mock_submit_job, _mock_legacy):
     assert result.returncode == 0, f"Subprocess failed with stderr: {result.stderr}"
     assert result.stderr == "", f"Subprocess produced stderr: {result.stderr}"
     assert "double quotes" in result.stdout
+
+
+@patch("cryri.api.use_legacy_backend", return_value=False)
+@patch("cryri.api.submit_job")
+def test_submit_run_batched_commands_executes_all(mock_submit_job, _mock_legacy, tmp_path):
+    mock_submit_job.return_value = {"job_name": "test_job_id_456"}
+
+    config_dict = {
+        "container": {
+            "image": "cr.ai.cloud.ru/aicloud-base-images/cuda12.1-torch2-py310:0.0.36",
+            "command": [
+                "echo first",
+                "sleep 0.1 && echo second",
+                "echo third",
+            ],
+            "execution": {"parallel": 2},
+            "work_dir": str(tmp_path),
+        },
+        "cloud": {
+            "region": "SR004",
+            "instance_type": "cpu.2C.8G",
+            "n_workers": 1,
+            "description": "batched submit test",
+        },
+    }
+    cfg = CryConfig(**config_dict)
+
+    jm = JobManager(cfg.cloud.region)
+    job_id = jm.submit_run(cfg)
+    assert job_id == "test_job_id_456"
+
+    _, kwargs = mock_submit_job.call_args
+    script_command = kwargs.get("script")
+    assert script_command is not None
+    assert script_command.startswith("bash -c ")
+    assert ".cryri/batch_scripts/cryri_batch_" in script_command
+
+    result = subprocess.run(
+        script_command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"Subprocess failed with stderr: {result.stderr}"
+    assert "[cryri] Starting execution" in result.stdout
+    assert "first" in result.stdout
+    assert "second" in result.stdout
+    assert "third" in result.stdout


### PR DESCRIPTION
## What changed

- Added command batching support in single-job configs:
  - `container.command` now supports either string or list.
  - `container.execution.parallel` controls per-batch parallelism.
- Added modular batch script builder in `cryri/script_builder.py`.
- Updated submit flow in `cryri/job_manager.py`:
  - For list commands, generate a script in `.cryri/batch_scripts/`.
  - Submit a launcher command to avoid API special-character rejection.
- Updated Rich config preview in `cryri/display.py`:
  - Batch grouping labels.
  - Consistent color mapping for commands in the same batch.
  - Safe command rendering via Rich markup escaping.
- Updated tests in `tests/test_main.py` and `tests/test_submit_run.py`.
- Updated `README.md` with batching terminology and examples.

## Why

Complex inline `script` payloads with special characters are rejected.
Batching through generated local scripts preserves the new functionality while keeping the submitted launcher API-safe.
